### PR TITLE
loosen up deps, so we can upgrade security updates

### DIFF
--- a/devise_ldap_authenticatable.gemspec
+++ b/devise_ldap_authenticatable.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency('devise', '>= 3.4.1')
-  s.add_dependency('net-ldap', '>= 0.6.0', '<= 0.11')
+  s.add_dependency('devise', '~> 3.4.0')
+  s.add_dependency('net-ldap', '>= 0.6.0', '< 1.0')
 
   s.add_development_dependency('rake', '>= 0.9')
   s.add_development_dependency('rdoc', '>= 3')


### PR DESCRIPTION
Net::LDAP version 0.11 has a security problem (not verifying SSL certs), hence
we need to be able to upgrade this dependency